### PR TITLE
Fix: add `['path']` and fix "sha1.blob.tch" paths

### DIFF
--- a/woc/local.pyx
+++ b/woc/local.pyx
@@ -815,7 +815,7 @@ class WocMapsLocal(WocMapsBase):
             _map_obj = self.config['objects']['blob.bin']
             shard = get_shard(key, _map_obj['sharding_bits'], use_fnv_keys=False)
 
-            with open(_map_obj['shards'][shard], "rb") as f:
+            with open(_map_obj['shards'][shard]['path'], "rb") as f:
                 f.seek(offset)
                 _out_bin = f.read(length)
             if self._is_debug_enabled:


### PR DESCRIPTION
I failed to replicate the `woc.show_content("blob", "05fe634ca4c8386349ac519f899145c75fff4169")` example in the README. After an investigation into the code and the environment, I found two errors:
1. The default `/home/wocprofile.json` specify the path of "sha1.blob.tch" as `/da5_fast/All.sha1/`, which should be `/da5_fast/All.sha1o/`. It leads to `AssertionError: Invalid (offset, length) pair` since only the 1st field (id) in the blob.idx file is returned whereas the 2nd (offset) and 3rd (compressed_length) fields are expected. However, since the wocprofile.json is not contained in the repository, I did not fix in this commit. **Please change the default `/home/wocprofile.json` in the da servers**.
2. When reading blob raw content from blob.bin files, the value of `path` key should be accessed according to current `wocprofiles.json`'s data schema.